### PR TITLE
Give proper name to webpack output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
     publicPath: 'dist',
-    filename: 'bundle.js',
+    filename: 'json-formatter.js',
     library: 'JSONFormatter',
     libraryTarget: 'umd',
     umdNamedDefine: true


### PR DESCRIPTION
I'd give a real name to your distribution files instead of generic 'bundle'. Main reason is some people will want to copy over your dist folder to their static resources folder, and this can be done only if files have a distinctive name.