### PR TITLE
make escapeString function actually escape

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,7 @@
  * Escapes `"` charachters from string
 */
 function escapeString(str: string): string {
-  return str.replace('"', '\\"');
+  return str.replace(/"/g, '\\"');
 }
 
 /*

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,7 @@
  * Escapes `"` charachters from string
 */
 function escapeString(str: string): string {
-  return str.replace('"', '\"');
+  return str.replace('"', '\\"');
 }
 
 /*


### PR DESCRIPTION
I noticed that the regEx in `escapeString` only looks like it replaces `"` with `\"`. But since `\"` gets interpreted as an escaped double quote, it instead replaces `"` with itself.

I changed the regEx to achieve what I assume is the intended behaviour.

Disclaimer: I work for a company that does automatic code review and whose website [flagged](https://lgtm.com/projects/g/mohsen1/json-formatter-js/alerts/?mode=list) up this issue; this is how I noticed it.