### PR TITLE
add support for overrideName and showProperty functions on config object (fixes #74)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ export interface JSONFormatterConfiguration {
   theme?: string;
   useToJSON?: boolean;
   sortPropertiesBy?: (a: string, b: string) => number;
+  overrideName?: (obj: any) => string;
+  showProperty?: (obj: any, key: string) => boolean;
 };
 
 const _defaultConfig: JSONFormatterConfiguration = {
@@ -37,7 +39,9 @@ const _defaultConfig: JSONFormatterConfiguration = {
   animateClose: true,
   theme: null,
   useToJSON: true,
-  sortPropertiesBy: null
+  sortPropertiesBy: null,
+  overrideName: null,
+  showProperty: null
 };
 
 
@@ -185,6 +189,9 @@ export default class JSONFormatter {
    * if this is an object, get constructor function name
   */
   private get constructorName(): string {
+    if (this.config.overrideName) {
+      return this.config.overrideName(this.json) || getObjectName(this.json);
+    }
     return getObjectName(this.json);
   }
 
@@ -437,8 +444,10 @@ export default class JSONFormatter {
 
     } else {
       this.keys.forEach(key => {
-        const formatter = new JSONFormatter(this.json[key], this.open - 1, this.config, key);
-        children.appendChild(formatter.render());
+        if (!this.config.showProperty || this.config.showProperty(this.json, key)) {
+          const formatter = new JSONFormatter(this.json[key], this.open - 1, this.config, key);
+          children.appendChild(formatter.render());
+        }
       });
     }
   }

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -184,3 +184,35 @@ describe('toggleOpen before any rendering', () => {
         expect(element.outerHTML).not.toContain('depth4');
     });
 });
+
+describe('overrideName', () => {
+    it('should override the displayed object name', () => {
+        const formatter = new JSONFormatter([{type: 'apple'}, {type: 'orange'}, {noType: 'banana'}], Infinity, {
+            animateOpen: false,
+            animateClose: false,
+            overrideName: function(obj) { return obj.type; }
+        });
+        const element = formatter.render();
+        expect(element.querySelectorAll('.json-formatter-constructor-name')[1].textContent).toContain('apple');
+        expect(element.querySelectorAll('.json-formatter-constructor-name')[2].textContent).toContain('orange');
+        expect(element.querySelectorAll('.json-formatter-constructor-name')[3].textContent).toContain('Object');
+    });
+});
+
+describe('showProperty', () => {
+    it('should hide properties', () => {
+        const formatter = new JSONFormatter([{type: 'apple', hidden: 'one'}, {type: 'orange', hidden: 'two'}], Infinity, {
+            animateOpen: false,
+            animateClose: false,
+            showProperty: function(obj, key) { return key !== 'hidden'; }
+        });
+        const element = formatter.render();
+        expect(element.outerHTML).toContain('type');
+        expect(element.outerHTML).toContain('apple');
+        expect(element.outerHTML).toContain('orange');
+        expect(element.outerHTML).not.toContain('hidden');
+        expect(element.outerHTML).not.toContain('one');
+        expect(element.outerHTML).not.toContain('two');
+    });
+});
+


### PR DESCRIPTION
* overrideName: allows developer to customize displayed name for plain objects
* showProperty: allows developer to hide certain properties