### PR TITLE
Fix a bug that makes ["string"] throws and null preview render as empty

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,11 @@ function escapeString(str: string): string {
   return str.replace(/"/g, '\\"');
 }
 
+export function getType(value: any): string {
+  if (value === null) { return 'null'; }
+  return typeof value;
+}
+
 /*
  * Determines if a value is an object
 */
@@ -60,14 +65,14 @@ export function getValuePreview (type: string, object: Object, value: string): s
 /*
  * Generates inline preview for a JavaScript object
 */
-export function getPreview(type: string, object: string): string {
+export function getPreview(object: any): string {
   let value = '';
   if (isObject(object)) {
     value = getObjectName(object);
     if (Array.isArray(object))
       value += '[' + object.length + ']';
   } else {
-    value = getValuePreview(type, object, object);
+    value = getValuePreview(getType(object), object, object);
   }
   return value;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  getType,
   isObject,
   getObjectName,
   getValuePreview,
@@ -193,9 +194,8 @@ export default class JSONFormatter {
    * Possible values: all JavaScript primitive types plus "array" and "null"
   */
   private get type(): string {
-    if (this.json === null) { return 'null'; }
     if (this.config.useToJSON && this.json && this.json['toJSON']) { return 'stringifiable'; }
-    return typeof this.json;
+    return getType(this.json)
   }
 
   /*
@@ -277,7 +277,7 @@ export default class JSONFormatter {
       const narrowKeys = keys.slice(0, this.config.hoverPreviewFieldCount);
 
       // json value schematic information
-      const kvs = narrowKeys.map(key => `${key}:${getPreview(this.type, this.json[key])}`);
+      const kvs = narrowKeys.map(key => `${key}:${getPreview(this.json[key])}`);
 
       // if keys count greater then 5 then show ellipsis
       const ellipsis = keys.length >= this.config.hoverPreviewFieldCount ? '…' : '';


### PR DESCRIPTION
Fixes #72 

Also, fix a bug where an array preview shows the indexes but not contents.
![image](https://user-images.githubusercontent.com/3322485/69914957-73bf1d80-1452-11ea-8ca6-58dcdfbc9458.png)

Also, fix a bug where, once fixed the above, the null was rendered as empty so `[0, , { a:1, b:2 }]` instead of `[0, null, { a:1, b:2 }]`