### PR TITLE
feat: add exports field to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 .git
+.github
+mocks
+test
 src
 !dist/src

--- a/package.json
+++ b/package.json
@@ -2,10 +2,19 @@
   "name": "json-formatter-js",
   "version": "2.4.0",
   "description": "JSON Formatter core library ",
-  "main": "dist/json-formatter.cjs.js",
-  "module": "dist/json-formatter.esm.js",
+  "main": "dist/json-formatter.cjs",
+  "module": "dist/json-formatter.mjs",
   "browser": "dist/json-formatter.umd.js",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "dist/json-formatter.mjs",
+      "require": "dist/json-formatter.cjs",
+      "browser": "dist/json-formatter.umd.cjs",
+      "types": "dist/src/index.d.ts",
+      "default": "dist/json-formatter.cjs"
+    }
+  },
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c rollup.dev.config.js",


### PR DESCRIPTION
Hi @mohsen1, thanks for creating `json-formatter-js`.

This library is currently hard to use with bundlers like `webpack` or `esbuild` when using ES modules, because often the `browser` field in `package.json` is preferred over the `module` field which actually contains the ES bundle of this library.

This PR adds the more modern `exports` fields to the `package.json` and configures the [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) for the different environments accordingly.

Let me know what you think about this change.