### PR TITLE
fix: add `./` to exports paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "dist/json-formatter.mjs",
-      "require": "dist/json-formatter.cjs",
-      "browser": "dist/json-formatter.umd.cjs",
-      "types": "dist/src/index.d.ts",
-      "default": "dist/json-formatter.cjs"
+      "import": "./dist/json-formatter.mjs",
+      "require": "./dist/json-formatter.cjs",
+      "browser": "./dist/json-formatter.umd.cjs",
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/json-formatter.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
Hi @mohsen1, this is a fix for #134. Sorry for introducing that regression with my PR #129.

I have reproduced the error described in #134 and these changes fixed it.