### PR TITLE
fix: improve url detection to avoid false positives

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const DATE_STRING_REGEX =
   /(^\d{1,4}[\.|\\/|-]\d{1,2}[\.|\\/|-]\d{1,4})(\s*(?:0?[1-9]:[0-5]|1(?=[012])\d:[0-5])\d\s*[ap]m)?$/;
 const PARTIAL_DATE_REGEX = /\d{2}:\d{2}:\d{2} GMT-\d{4}/;
 const JSON_DATE_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
+const URL_REGEX = /^https?:\/\//;
 
 // When toggleing, don't animated removal or addition of more than a few items
 const MAX_ANIMATED_TOGGLE_ITEMS = 10;
@@ -169,7 +170,7 @@ export default class JSONFormatter {
    * is this a URL string?
    */
   private get isUrl(): boolean {
-    return this.type === "string" && this.json.indexOf("http") === 0;
+    return this.type === "string" && URL_REGEX.test(this.json);
   }
 
   /*

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -109,6 +109,16 @@ describe("url string", () => {
   });
 });
 
+describe("url detection shouldn't generate false positive for words starting with http", () => {
+  const formatter = new JSONFormatter("httpstatus");
+
+  it("should not make a link and add class 'url'", () => {
+    expect(formatter.render().querySelector("a.json-formatter-url")).toEqual(
+      null,
+    );
+  });
+});
+
 describe("object with empty property", () => {
   const formatter = new JSONFormatter({ "": true });
 


### PR DESCRIPTION
I've noticed that the url detection is a bit too simple as it creates false hyperlinks for regular words starting with http.

e.g. `httpstatus` would create a hyperlink even if it's unlikely expected to be there.

Note: I'm not sure if it's only for me but the `test` script isn't working. It also seems like there's no github action to actually execute the tests.

```
 FAIL  test/spec.ts
  ● Test suite failed to run

    TypeError: Cannot read properties of undefined (reading 'createNodeArray')

      at visitor (node_modules/ts-jest/dist/transformers/hoist-jest.js:84:61)
```